### PR TITLE
adding contributors dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,21 +210,6 @@ Please adhere towards our [code-of-conduct.md](code-of-conduct.md).
 
 ## Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
-
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tr>
-    <td align="center"><a href="https://www.linkedin.com/in/navpreet-kaur24/"><img src="https://avatars1.githubusercontent.com/u/59786562?v=4" width="100px;" alt=""/><br /><sub><b>Navpreet Kaur</b></sub></a><br /><a href="https://github.com/garimasingh128/profext/commits?author=navu9999" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://sundaram-dubey.netlify.app/"><img src="https://avatars2.githubusercontent.com/u/56407566?v=4" width="100px;" alt=""/><br /><sub><b>Sundaram Dubey</b></sub></a><br /><a href="https://github.com/garimasingh128/profext/commits?author=maze-runnar" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/oshinsaini"><img src="https://avatars3.githubusercontent.com/u/56020411?v=4" width="100px;" alt=""/><br /><sub><b>oshinsaini</b></sub></a><br /><a href="https://github.com/garimasingh128/profext/commits?author=oshinsaini" title="Documentation">📖</a></td>
-  </tr>
-</table>
-
-<!-- markdownlint-enable -->
-<!-- prettier-ignore-end -->
-<!-- ALL-CONTRIBUTORS-LIST:END -->
-
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+<a href="https://github.com/garimasingh128/profext/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=garimasingh128/profext" />
+</a>

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,7 +6,7 @@ Fixes # (issue)
 
 ## Type of change
 
-Please delete options that are not relevant.
+Please delete options that are not relevant and insert x in the box to check the box.
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)


### PR DESCRIPTION
# Description
Now there is no need to add them manually. So if you want I can delete .all-contributor_src file. It is of no use from now.

Fixes #71 

## Type of change

Please delete options that are not relevant and insert x in the box to check the box.

- [x] New feature (non-breaking change which adds functionality)

## Screenshot

@garimasingh128 It look like this. 

![contributor](https://user-images.githubusercontent.com/59874304/102610235-d913a880-4152-11eb-8803-c7903f42e385.JPG)
